### PR TITLE
[PI-46] Add webpack configurations

### DIFF
--- a/webpack/mainnet.config.js
+++ b/webpack/mainnet.config.js
@@ -56,6 +56,15 @@ module.exports = {
         }
       },
       {
+        test: /pdf\.worker(\.min)?\.js$/,
+        use: 'raw-loader',
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: [/node_modules/, /pdf\.worker(\.min)?\.js$/],
+        use: 'babel-loader',
+      },
+      {
         test: /\.css$/,
         use: [
           'style-loader',

--- a/webpack/mainnet.config.js
+++ b/webpack/mainnet.config.js
@@ -55,6 +55,7 @@ module.exports = {
           presets: []
         }
       },
+      // Pdfjs Worker webpack config, reference to issue: https://github.com/mozilla/pdf.js/issues/7612#issuecomment-315179422
       {
         test: /pdf\.worker(\.min)?\.js$/,
         use: 'raw-loader',

--- a/webpack/staging.config.js
+++ b/webpack/staging.config.js
@@ -55,6 +55,16 @@ module.exports = {
           presets: []
         }
       },
+      // Pdfjs Worker webpack config, reference to issue: https://github.com/mozilla/pdf.js/issues/7612#issuecomment-315179422
+      {
+        test: /pdf\.worker(\.min)?\.js$/,
+        use: 'raw-loader',
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: [/node_modules/, /pdf\.worker(\.min)?\.js$/],
+        use: 'babel-loader',
+      },
       {
         test: /\.css$/,
         use: [

--- a/webpack/testnet.config.js
+++ b/webpack/testnet.config.js
@@ -55,6 +55,16 @@ module.exports = {
           presets: []
         }
       },
+      // Pdfjs Worker webpack config, reference to issue: https://github.com/mozilla/pdf.js/issues/7612#issuecomment-315179422
+      {
+        test: /pdf\.worker(\.min)?\.js$/,
+        use: 'raw-loader',
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: [/node_modules/, /pdf\.worker(\.min)?\.js$/],
+        use: 'babel-loader',
+      },
       {
         test: /\.css$/,
         use: [


### PR DESCRIPTION
Add missing webpack configurations for `pdfjs-dist` library.

This includes:
- Mainnet
- Testnet
- Staging