### PR TITLE
[PI-56] Fix paper vended redemption test

### DIFF
--- a/features/ada-redemption.feature
+++ b/features/ada-redemption.feature
@@ -79,16 +79,15 @@ Feature: Ada Redemption
     Then I should see the "Ada Redemption Success Overlay" and close the dialogue
     And I should see the summary screen
 
-  # #FIXME : https://trello.com/c/BNHN9Ufz/56-fix-paper-vended-redemption-test
-  # Scenario: User redeems manually entered "Paper vended" shielded vending key and passphrase
-  #   Given I have accepted "Daedalus Redemption Disclaimer"
-  #   And I click on ada redemption choices "Paper vended" tab
-  #   And I enter a valid "Paper vended" shielded vending key
-  #   And I enter a valid "Paper vended" shielded vending key passphrase
-  #   And ada redemption form submit button is no longer disabled
-  #   When I submit the ada redemption form
-  #   Then I should see the "Ada Redemption Success Overlay" and close the dialogue
-  #   And I should see the summary screen
+  Scenario: User redeems manually entered "Paper vended" shielded vending key and passphrase
+    Given I have accepted "Daedalus Redemption Disclaimer"
+    And I click on ada redemption choices "Paper vended" tab
+    And I enter a valid "Paper vended" shielded vending key
+    And I enter a valid "Paper vended" shielded vending key passphrase
+    And ada redemption form submit button is no longer disabled
+    When I submit the ada redemption form
+    Then I should see the "Ada Redemption Success Overlay" and close the dialogue
+    And I should see the summary screen
 
   Scenario: User redeems "Recovery - regular" encrypted PDF certificate
     Given I have accepted "Daedalus Redemption Disclaimer"

--- a/features/support/mockData.json
+++ b/features/support/mockData.json
@@ -437,6 +437,12 @@
         "tx_index": 1,
         "receiver": "Ae2tdPwUPEZ2UnSp2Px3wqZGJs3AUn5vcRQCTpPrcxGBWkAnAvB9JNNEtAb",
         "amount": "1000"
+      },
+      {
+        "tx_hash": "d2f5bc49b3688bf11d09145583a1b337c288dd8384c7495b74fedb3aeb528b04",
+        "tx_index": 1,
+        "receiver": "Ae2tdPwUPEZFS38pQd5nbC5vqyicSHSgRkjr5p3mFxRrVgVn2fMKSxDR1qY",
+        "amount": "1000"
       }
     ]
   }


### PR DESCRIPTION
The test to redeem ada using the paper vended method was broken, this was because there were some missing mock data.