### PR TITLE
[PI-65] Remove hasPassword variable in Wallet.js

### DIFF
--- a/app/domain/Wallet.js
+++ b/app/domain/Wallet.js
@@ -17,7 +17,6 @@ export default class Wallet {
   @observable amount: BigNumber;
   @observable assurance: AssuranceModeOption;
   @observable passwordUpdateDate: ?Date;
-  @observable hasPassword: boolean;
 
   /**
    * When creating Wallet object we can skip typeInfo,


### PR DESCRIPTION
This variable was added with the ada redemption form, but we forgot to remove it when we removed the spending password field.