### PR TITLE
[PI-68] Use Logger instead of console.log in AdaRedemptionForm

### DIFF
--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -27,7 +27,7 @@ import AdaRedemptionDisclaimer from './AdaRedemptionDisclaimer';
 import AdaCertificateUploadWidget from '../../widgets/forms/AdaCertificateUploadWidget';
 import { submitOnEnter } from '../../../utils/form';
 import styles from './AdaRedemptionForm.scss';
-import { Logger } from '../../../utils/logging';
+import { Logger, stringifyError } from '../../../utils/logging';
 
 const messages = defineMessages({
   headline: {
@@ -354,7 +354,7 @@ export default class AdaRedemptionForm extends Component<Props> {
           shieldedRedemptionKey
         });
       },
-      onError: (error) => Logger.error(error),
+      onError: (error) => Logger.error(`adaRedeem::submit ${stringifyError(error)}`),
     });
   };
 

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -27,6 +27,7 @@ import AdaRedemptionDisclaimer from './AdaRedemptionDisclaimer';
 import AdaCertificateUploadWidget from '../../widgets/forms/AdaCertificateUploadWidget';
 import { submitOnEnter } from '../../../utils/form';
 import styles from './AdaRedemptionForm.scss';
+import { Logger } from '../../../utils/logging';
 
 const messages = defineMessages({
   headline: {
@@ -353,7 +354,7 @@ export default class AdaRedemptionForm extends Component<Props> {
           shieldedRedemptionKey
         });
       },
-      onError: (error) => console.log(error),
+      onError: (error) => Logger.error(error),
     });
   };
 


### PR DESCRIPTION
By mistake we left a `console.log` to log an error instead of using the `Logger`