### PR TITLE
[PI-61] Fix number with no explanation in pdfParser

### DIFF
--- a/app/api/ada/lib/pdfParser.js
+++ b/app/api/ada/lib/pdfParser.js
@@ -20,17 +20,19 @@ export const getSecretKey = (parsedPDF: string): string => {
       throw new InvalidCertificateError();
     }
 
-    let index = 0;
+    let redemptionKeyIndex = 0;
 
     if (lastItem === '——————') {
-      index = splitArray.length - 5;
+      const elementsAfterRedemptionKey = 5;
+      redemptionKeyIndex = splitArray.length - elementsAfterRedemptionKey;
     }
 
     if (lastItem === 'KEY') {
-      index = splitArray.length - 3;
+      const elementsAfterRedemptionKey = 3;
+      redemptionKeyIndex = splitArray.length - elementsAfterRedemptionKey;
     }
 
-    return splitArray[index];
+    return splitArray[redemptionKeyIndex];
   } catch (error) {
     Logger.error('pdfParser::getSecretKey error: ' + stringifyError(error));
     if (error instanceof InvalidCertificateError) {

--- a/app/api/ada/lib/pdfParser.js
+++ b/app/api/ada/lib/pdfParser.js
@@ -21,18 +21,21 @@ export const getSecretKey = (parsedPDF: string): string => {
     }
 
     let redemptionKeyIndex = 0;
+    let elementsAfterRedemptionKey;
 
     if (lastItem === '——————') {
-      const elementsAfterRedemptionKey = 5;
+      elementsAfterRedemptionKey = 5;
       redemptionKeyIndex = splitArray.length - elementsAfterRedemptionKey;
     }
 
     if (lastItem === 'KEY') {
-      const elementsAfterRedemptionKey = 3;
+      elementsAfterRedemptionKey = 3;
       redemptionKeyIndex = splitArray.length - elementsAfterRedemptionKey;
     }
 
-    return splitArray[redemptionKeyIndex];
+    const redemptionKey = splitArray[redemptionKeyIndex];
+
+    return redemptionKey;
   } catch (error) {
     Logger.error('pdfParser::getSecretKey error: ' + stringifyError(error));
     if (error instanceof InvalidCertificateError) {


### PR DESCRIPTION
The numbers 5 and 3 in the pdfParser made reference to the amount of elements after the redemption key in the array, so a variable was added in order to make it more clear.