### PR TITLE
[PI-69] Use Styles variable instead of raw string

### DIFF
--- a/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.js
@@ -70,7 +70,7 @@ export default class AdaRedemptionDisclaimer extends Component<Props, State> {
 
         <p>{intl.formatMessage(messages.disclaimerText)}</p>
 
-        <div className="adaRedemptionDisclaimerCheckbox">
+        <div className={styles.adaRedemptionDisclaimerCheckbox}>
           <Checkbox
             label={intl.formatMessage(messages.checkboxLabel)}
             onChange={this.onAcceptToggle}

--- a/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.scss
+++ b/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.scss
@@ -48,8 +48,8 @@
     opacity: 0.8;
   }
 
-  :global .adaRedemptionDisclaimerCheckbox {
-    .SimpleCheckbox_root {
+  .adaRedemptionDisclaimerCheckbox {
+    :global .SimpleCheckbox_root {
       margin-bottom: 30px;
       opacity: 0.8;
       padding-top: 20px;


### PR DESCRIPTION
The 'styles' variable was used instead of raw strings for CSS.