### PR TITLE
[PI-80] Remove walletId and accountIndex in adaRedemption.js

### DIFF
--- a/app/api/ada/adaRedemption.js
+++ b/app/api/ada/adaRedemption.js
@@ -9,15 +9,11 @@ import { RedemptionKeyAlreadyUsedError } from './errors';
 import BigNumber from 'bignumber.js';
 
 export type RedeemAdaParams = {
-  redemptionCode: string,
-  walletId: string,
-  accountIndex: number
+  redemptionCode: string
 };
 
 export type RedeemPaperVendedAdaParams = {
   redemptionCode: string,
-  walletId: string,
-  accountIndex: number,
   mnemonics: Array<string>,
 };
 

--- a/app/stores/ada/AdaRedemptionStore.js
+++ b/app/stores/ada/AdaRedemptionStore.js
@@ -19,7 +19,6 @@ import { DECIMAL_PLACES_IN_ADA } from '../../config/numbersConfig';
 import environment from '../../environment';
 import BigNumber from 'bignumber.js';
 import Request from '../lib/LocalizedRequest';
-import { getSingleCryptoAccount } from '../../api/ada/adaLocalStorage';
 
 export default class AdaRedemptionStore extends Store {
 
@@ -199,19 +198,10 @@ export default class AdaRedemptionStore extends Store {
   _redeemAda = async ({ walletId } : {
     walletId: string
   }) => {
-
     runInAction(() => { this.walletId = walletId; });
-
-    // Since there's no support for multiwallet yet, the only account index present in localStorage
-    // is used.
-    const accountData = getSingleCryptoAccount();
-    const accountIndex = accountData.account;
-    if (!accountIndex && accountIndex !== 0) throw new Error('Active account required before redeeming Ada.');
 
     try {
       const transactionAmountInLovelace: BigNumber = await this.redeemAdaRequest.execute({
-        walletId,
-        accountIndex,
         redemptionCode: this.redemptionCode
       });
       this._reset();
@@ -231,15 +221,9 @@ export default class AdaRedemptionStore extends Store {
   }) => {
     runInAction(() => { this.walletId = walletId; });
 
-    const accountData = getSingleCryptoAccount();
-    const accountIndex = accountData.account;
-    if (!accountIndex && accountIndex !== 0) throw new Error('Active account required before redeeming Ada.');
-
     try {
       const transactionAmountInLovelace: BigNumber =
         await this.redeemPaperVendedAdaRequest.execute({
-          walletId,
-          accountIndex,
           redemptionCode: shieldedRedemptionKey,
           mnemonics: this.passPhrase && this.passPhrase.split(' ')
         });


### PR DESCRIPTION
The fields `walletId` and `accountIndex` were actually never used in both types. The `accountIndex` was also removed from the adaRedemptionStore file because it wasn't being used.