### PR TITLE
[PI-81] The "Redeem your money" button is not blocked quickly enough

### DIFF
--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -410,21 +410,12 @@ export default class AdaRedemptionForm extends Component<Props> {
     );
 
     let canSubmit = false;
-    if ((
-      redemptionType === ADA_REDEMPTION_TYPES.REGULAR ||
-      redemptionType === ADA_REDEMPTION_TYPES.RECOVERY_REGULAR) &&
-      redemptionCode !== ''
-    ) canSubmit = true;
-    if ((
-      redemptionType === ADA_REDEMPTION_TYPES.FORCE_VENDED ||
-      redemptionType === ADA_REDEMPTION_TYPES.RECOVERY_FORCE_VENDED) &&
-      redemptionCode !== ''
-    ) canSubmit = true;
     if (
       redemptionType === ADA_REDEMPTION_TYPES.PAPER_VENDED &&
       shieldedRedemptionKeyField.isDirty &&
       passPhraseField.isDirty
     ) canSubmit = true;
+    else canSubmit = this.props.canSubmit;
 
     let instructionMessage = '';
     let instructionValues = {};

--- a/app/containers/wallet/AdaRedemptionPage.js
+++ b/app/containers/wallet/AdaRedemptionPage.js
@@ -39,7 +39,7 @@ export default class AdaRedemptionPage extends Component<InjectedProps> {
       redeemAdaRequest, redeemPaperVendedAdaRequest,
       isCertificateEncrypted, redemptionType, error,
       isRedemptionDisclaimerAccepted, isValidRedemptionMnemonic,
-      isValidRedemptionKey, isValidPaperVendRedemptionKey
+      isValidRedemptionKey, isValidPaperVendRedemptionKey, canSubmit
     } = adaRedemption;
     const {
       chooseRedemptionType, setRedemptionCode, setCertificate, setPassPhrase, setEmail,
@@ -121,6 +121,7 @@ export default class AdaRedemptionPage extends Component<InjectedProps> {
           )}
           isRedemptionDisclaimerAccepted={isMainnet || isRedemptionDisclaimerAccepted}
           onAcceptRedemptionDisclaimer={() => acceptRedemptionDisclaimer.trigger()}
+          canSubmit={canSubmit}
         />
       </div>
     );

--- a/app/stores/ada/AdaRedemptionStore.js
+++ b/app/stores/ada/AdaRedemptionStore.js
@@ -38,6 +38,7 @@ export default class AdaRedemptionStore extends Store {
   @observable redeemPaperVendedAdaRequest: Request<RedeemPaperVendedAdaParams> = new Request(this.api.ada.redeemPaperVendedAda);
   @observable amountRedeemed: number = 0;
   @observable showAdaRedemptionSuccessMessage: boolean = false;
+  @observable canSubmit: boolean = false;
 
   setup() {
     const actions = this.actions.ada.adaRedemption;
@@ -100,6 +101,7 @@ export default class AdaRedemptionStore extends Store {
   });
 
   _setPassPhrase = action(({ passPhrase } : { passPhrase: string }) => {
+    this.canSubmit = false;
     this.passPhrase = passPhrase;
     if (this.isValidRedemptionMnemonic(passPhrase)) this._parseCodeFromCertificate();
   });
@@ -109,21 +111,25 @@ export default class AdaRedemptionStore extends Store {
   });
 
   _setEmail = action(({ email } : { email: string }) => {
+    this.canSubmit = false;
     this.email = email;
     this._parseCodeFromCertificate();
   });
 
   _setAdaPasscode = action(({ adaPasscode } : { adaPasscode: string }) => {
+    this.canSubmit = false;
     this.adaPasscode = adaPasscode;
     this._parseCodeFromCertificate();
   });
 
   _setAdaAmount = action(({ adaAmount } : { adaAmount: string }) => {
+    this.canSubmit = false;
     this.adaAmount = adaAmount;
     this._parseCodeFromCertificate();
   });
 
   _setDecryptionKey = action(({ decryptionKey } : { decryptionKey: string }) => {
+    this.canSubmit = false;
     this.decryptionKey = decryptionKey;
     this._parseCodeFromCertificate();
   });
@@ -173,6 +179,7 @@ export default class AdaRedemptionStore extends Store {
   _onCodeParsed = action(code => {
     Logger.debug('Redemption code parsed from certificate: ' + code);
     this.redemptionCode = code;
+    this.canSubmit = true;
   });
 
   _onParseError = action((error) => {
@@ -265,6 +272,7 @@ export default class AdaRedemptionStore extends Store {
     this.redemptionCode = '';
     this.passPhrase = null;
     this.decryptionKey = null;
+    this.canSubmit = false;
   });
 
   @action _reset = () => {


### PR DESCRIPTION
Basically the redeem button took to long to be disabled because it waited for the redemption code to be successfully parsed and decrypted, while the input (for example, of the Ada Amount field) changed immediately.
The approach in this PR was to disable the button every time any of those fields change and enable it only when the redemption code has been successfully parsed and decoded. This was done for Regular, Recovery-Regular, Force Vended and Recovery-Force-Vended. For Paper Vended the old behavior was kept, as it depends on other fields from the AdaRedemptionForm. 